### PR TITLE
.gitignore will now ignore .vscode/settings.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,7 +43,6 @@ sdkconfig.old
 
 ### VisualStudioCode ###
 .vscode/*
-!.vscode/settings.json
 !.vscode/tasks.json
 !.vscode/launch.json
 !.vscode/extensions.json


### PR DESCRIPTION
Removed the following line from .gitignore:
```
!.vscode/settings.json
```

Note: I based the changes on main, since I figure this isn't really specific to the "test" series of branches. If you think its better just on test though, let me know and I'll fix it to be that way :)