### PR TITLE
sweep only once after move; jump instead of move

### DIFF
--- a/main/states.c
+++ b/main/states.c
@@ -354,9 +354,10 @@ ls_State ls_state_manual(ls_event event)
         {
             _ls_state_manual_servo_hold_count--;
         }
-        else
+        else if (_ls_state_manual_servo_hold_count == 0)
         {
             ls_servo_sweep();
+            _ls_state_manual_servo_hold_count = -1;
         }
         break;
     case LSEVT_CONTROLS_SPEED:
@@ -367,13 +368,13 @@ ls_State ls_state_manual(ls_event event)
     case LSEVT_CONTROLS_TOPANGLE:
         control_value = *((BaseType_t *)event.value);
         ls_settings_set_servo_top(ls_settings_map_control_to_servo_top(control_value));
-        ls_servo_moveto(ls_settings_get_servo_top());
+        ls_servo_jumpto(ls_settings_get_servo_top());
         _ls_state_manual_servo_hold_count = 3;
         break;
     case LSEVT_CONTROLS_BOTTOMANGLE:
         control_value = *((BaseType_t *)event.value);
         ls_settings_set_servo_bottom(ls_settings_map_control_to_servo_bottom(control_value));
-        ls_servo_moveto(ls_settings_get_servo_bottom());
+        ls_servo_jumpto(ls_settings_get_servo_bottom());
         _ls_state_manual_servo_hold_count = 3;
         break;
     case LSEVT_CONTROLS_DISCONNECTED:


### PR DESCRIPTION
@ijchen Please make the change that your sweep mode resets its target only on entering sweep mode (see comments on your PR #24 ) and test it by ensuring that it can sweep all the way up and down (with top and bottom set appropriately) *before* you merge this code. This change will avoid sending multiple `ls_servo_sweep()` calls from manual mode. While each independently fixes the problem, I think both should be done. (I've tested this code against the what was already in dev_servo.)

So, 1) make the changes I asked for in servo.c, 2) push up your updated dev-servo branch, 3) merge this branch which changes only states.c, 4) let me know to pull dev-servo retest and see whether everything looks good to me for that PR.

Thanks!