### PR TITLE
send 50 reads after slider move ignoring threshold

### DIFF
--- a/main/config.h
+++ b/main/config.h
@@ -90,8 +90,10 @@
 // any ADC reading <= LS_CONTROLS_READING_BOTTOM is considered min
 #define LS_CONTROLS_READING_BOTTOM 50
 // any ADC reading must change by this much from its previous value to be registered.
-#define LS_CONTROLS_READING_HYSTERISIS 7
-
+#define LS_CONTROLS_READING_MOVE_THRESHOLD 20
+#define LS_CONTROLS_READINGS_TO_AVERAGE 5
+// when controls are connected, readings are sent every tick, so 50 reads=~5sec
+#define LS_CONTROLS_FASTREADS_AFTER_MOVE 50
 
 // values read by ADC for tape reflectance sensor
 // based on testing conducted March 18 '22
@@ -111,14 +113,14 @@
 #define LS_MAP_RESOLUTION (LS_STEPPER_STEPS_PER_ROTATION / 400)
 #define LS_MAP_ALLOWABLE_MISREAD_PERCENT 4
 
-// how often should we rehome if using the map? 10000=10s debug/test, 3600000=1h production
+// how often should we rehome if using the map? 10000=10s debug/test, 1800000=30min production
 #ifdef LSDEBUG_HOMING
 #define LS_STATE_REHOME_TIMER_PERIOD_MS 10000
 #else
-#define LS_STATE_REHOME_TIMER_PERIOD_MS 3600000
+#define LS_STATE_REHOME_TIMER_PERIOD_MS 1800000
 #endif
 
-// light levels based on sample data recorded in light.h
+// light levels based on sample data recorded in lightsense.h; roughly 40lux on, 20lux off
 #define LS_LIGHTSENSE_DAY_THRESHOLD 1000
 #define LS_LIGHTSENSE_NIGHT_THRESHOLD 500
 #define LS_LIGHTSENSE_READING_INTERVAL_MS 4000

--- a/main/states.c
+++ b/main/states.c
@@ -211,7 +211,7 @@ ls_State ls_state_prelaserwarn(ls_event event)
     }
     if (_ls_state_prelaserwarn_buzzer_complete && _ls_state_prelaserwarn_movement_complete)
     {
-        if (NULL == _ls_state_prelaserwarn_successor) 
+        if (NULL == _ls_state_prelaserwarn_successor)
         {
             _ls_state_prelaserwarn_successor = ls_state_active; // default
         }
@@ -322,7 +322,7 @@ ls_State ls_state_home(ls_event event)
         ls_event_enqueue_noop();
         break;
     case LSEVT_HOME_COMPLETED:
-        if(NULL == _ls_state_home_successor)
+        if (NULL == _ls_state_home_successor)
         {
             _ls_state_home_successor = ls_state_active;
         }
@@ -379,6 +379,9 @@ ls_State ls_state_manual(ls_event event)
             ls_servo_sweep();
             _ls_state_manual_servo_hold_count = -1;
         }
+        break;
+    case LSEVT_SERVO_FINISHED_MOVE:
+        ls_buzzer_play(LS_BUZZER_CLICK);
         break;
     case LSEVT_CONTROLS_SPEED:
         control_value = *((BaseType_t *)event.value);
@@ -477,7 +480,7 @@ ls_State ls_state_sleep(ls_event event)
             ls_state_set_home_successor(ls_state_prelaserwarn);
             successor.func = ls_state_home;
         }
-        else 
+        else
         {
             successor.func = ls_state_prelaserwarn;
         }


### PR DESCRIPTION
The ADC reading of the sliders is imprecise, including some random variation despite 5x sampling and a filter capacitor. A software threshold is implemented to distinguish a deliberate slider movement from random variation. Without this, all sliders would seem to be moving constantly and we would never return to the servo sweep mode, for example. 

However, requiring the threshold to be exceeded for every reading leads to jerky, imprecise adjustments and an inability to select a value close to the current value.

To partially remedy this problem, when a slider movement does exceed the threshold, that slider is flagged and up to 50 further movements (about 5 seconds) will always be read and their event data sent. The current design allows only one slider to be in this "fastread" mode.

(maybe I'll be better about creating issues before I fix them once we have a release?)