### PR TITLE
remap gpio; fail if no accelerometer

### DIFF
--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -1,2 +1,2 @@
-idf_component_register(SRCS "selftest.c" "lis2dh12.c" "i2c.c" "util.c" "settings.c" "servo.c" "lightsense.c" "tape.c" "map.c" "tapemode.c" "substate_home.c" "controls.c" "states.c" "events.c" "magnet.c" "laser.c" "init.c" "stepper.c" "mpu6050.c" "kxtj3.c" "buzzer.c" "ls2022_esp32.c"
+idf_component_register(SRCS "selftest.c" "lis2dh12.c" "i2c.c" "util.c" "settings.c" "servo.c" "lightsense.c" "tape.c" "map.c" "tapemode.c" "substate_home.c" "controls.c" "states.c" "events.c" "magnet.c" "laser.c" "init.c" "stepper.c" "mpu6050.c" "kxtj3.c" "buzzer.c" "config.c" "ls2022_esp32.c"
                     INCLUDE_DIRS ".")

--- a/main/config.c
+++ b/main/config.c
@@ -1,0 +1,43 @@
+#include "config.h"
+
+gpio_num_t IRAM_ATTR _lsgpio_laserpowerenable = 32; // Nov '21 = 33
+gpio_num_t _lsgpio_laserheaterenable = 26;          // Nov '21 = 32
+gpio_num_t _lsgpio_stepperdirection = 19;           // Nov '21 = 5
+gpio_num_t _lsgpio_steppersleep = 5;                // Nov '21 = 19
+gpio_num_t _lsgpio_servopowerenable = 25;           // Nob '21 = 26
+gpio_num_t _lsgpio_servopulse = 33;                 // Nov '21 = 25
+
+gpio_num_t IRAM_ATTR lsgpio_laserpowerenable()
+{
+    return _lsgpio_laserpowerenable;
+}
+gpio_num_t lsgpio_laserheaterenable()
+{
+    return _lsgpio_laserheaterenable;
+}
+gpio_num_t lsgpio_stepperdirection()
+{
+    return _lsgpio_stepperdirection;
+}
+gpio_num_t lsgpio_steppersleep()
+{
+    return _lsgpio_steppersleep;
+}
+gpio_num_t lsgpio_servopowerenable(void)
+{
+    return _lsgpio_servopowerenable;
+}
+gpio_num_t lsgpio_servopulse(void)
+{
+    return _lsgpio_servopulse;
+}
+
+void ls_config_set_gpio_nov21(void)
+{
+    _lsgpio_laserpowerenable = 33;
+    _lsgpio_laserheaterenable = 32;
+    _lsgpio_stepperdirection = 5;
+    _lsgpio_steppersleep = 19;
+    _lsgpio_servopowerenable = 26;
+    _lsgpio_servopulse = 25;
+}

--- a/main/config.h
+++ b/main/config.h
@@ -1,5 +1,17 @@
 #pragma once
 #include "debug.h"
+#include "driver/gpio.h"
+
+// these GPIO assignments changed from the Nov '21 test board (rectangular)
+// to the January/April '22 kit boards. On detecting the MPU6050 accelerometer
+// that was on only the Nov '21 boards, these can be return different values.
+void ls_config_set_gpio_nov21(void);
+gpio_num_t IRAM_ATTR lsgpio_laserpowerenable(void);
+gpio_num_t lsgpio_laserheaterenable(void);
+gpio_num_t lsgpio_stepperdirection(void);
+gpio_num_t lsgpio_steppersleep(void);
+gpio_num_t lsgpio_servopowerenable(void);
+gpio_num_t lsgpio_servopulse(void);
 
 // assignments of our devices to ESP32 peripherals
 #define LSBUZZER_HS_LEDC_CHANNEL 0
@@ -30,15 +42,15 @@
 // MAGNETSENSE is digital input (ISR), not ADC
 #define LSGPIO_MAGNETSENSE 4
 // Binary output
-#define LSGPIO_LASERPOWERENABLE 32
-#define LSGPIO_SERVOPOWERENABLE 25
-#define LSGPIO_LASERHEATERENABLE 26
+#define LSGPIO_LASERPOWERENABLE (lsgpio_laserpowerenable())
+#define LSGPIO_SERVOPOWERENABLE (lsgpio_servopowerenable())
+#define LSGPIO_LASERHEATERENABLE (lsgpio_laserheaterenable())
 #define LSGPIO_REFLECTANCEENABLE 27
-#define LSGPIO_STEPPERDIRECTION 19
+#define LSGPIO_STEPPERDIRECTION (lsgpio_stepperdirection())
 #define LSGPIO_STEPPERSTEP 18
-#define LSGPIO_STEPPERSLEEP 5
+#define LSGPIO_STEPPERSLEEP (lsgpio_steppersleep())
 // PWM output (LEDC)
-#define LSGPIO_SERVOPULSE 33
+#define LSGPIO_SERVOPULSE (lsgpio_servopulse())
 #define LSGPIO_BUZZERENABLE 2
 // I2C (using controller 0; pins selected to match Arduino usage; maybe they have a reason?)
 #define LSIC2_PORT I2C_NUM_0

--- a/main/debug.h
+++ b/main/debug.h
@@ -15,7 +15,7 @@
 extern SemaphoreHandle_t print_mux; // in ls2022_esp32.c
 
 //variadic macro help from https://gcc.gnu.org/onlinedocs/cpp/Variadic-Macros.html
-#define ls_debug_printf(args...) { xSemaphoreTake(print_mux, portMAX_DELAY); printf(args); xSemaphoreGive(print_mux); }
+#define ls_debug_printf(args...) { xSemaphoreTake(print_mux, 1); printf(args); xSemaphoreGive(print_mux); }
 
 // Uncomment any desired classes of debug output to enable output via ls_debug_printf
 

--- a/main/i2c.c
+++ b/main/i2c.c
@@ -37,6 +37,9 @@ static enum ls_i2c_accelerometer_device_t _ls_i2c_accelerometer_device = LS_I2C_
  */
 static esp_err_t i2c_master_init(void)
 {
+#ifdef LSDEBUG_I2C
+    ls_debug_printf("I2C bus master initializing...\n");
+#endif
     int i2c_master_port = LSIC2_PORT;
 
     i2c_config_t conf = {
@@ -87,6 +90,11 @@ bool ls_i2c_init(void)
     if (!_ls_i2c_initialized && i2c_master_init() == ESP_OK)
     {
         _ls_i2c_initialized = true;
+#ifdef LSDEBUG_I2C
+        ls_debug_printf("I2C LIS2DH: %d\n", ls_i2c_has_lis2dh12());
+        ls_debug_printf("I2C KXTJ3: %d\n", ls_i2c_has_kxtj3());
+        ls_debug_printf("I2C MPU6050: %d\n", ls_i2c_has_mpu6050());
+#endif
     }
     return _ls_i2c_initialized;
 }
@@ -242,12 +250,12 @@ void ls_tilt_task(void *pvParameter)
                     break;
                 default:;
                 }
-            current_status = readings[0];
+                current_status = readings[0];
 #ifdef LSDEBUG_TILT
-            ls_debug_printf("I2C tilt status now = %d\n", current_status);
+                ls_debug_printf("I2C tilt status now = %d\n", current_status);
 #endif
             } // new status
-        } // all agree
+        }     // all agree
         vTaskDelay(pdMS_TO_TICKS(LS_TILT_REPORT_RATE_MS));
     }
 }

--- a/main/init.c
+++ b/main/init.c
@@ -98,21 +98,3 @@ void check_efuse(void)
 #error "This example is configured for ESP32/ESP32S2."
 #endif
 }
-
-esp_err_t lsi_2c_master_init(void)
-{
-    i2c_config_t conf = {
-        .mode = I2C_MODE_MASTER,
-        .sda_io_num = LSI2C_SDA,
-        .sda_pullup_en = GPIO_PULLUP_ENABLE,
-        .scl_io_num = LSI2C_SCL,
-        .scl_pullup_en = GPIO_PULLUP_ENABLE,
-        .master.clk_speed = LSI2C_FREQ_HZ,
-        // .clk_flags = 0,          /*!< Optional, you can use I2C_SCLK_SRC_FLAG_* flags to choose i2c source clock here. */
-    };
-    esp_err_t err = i2c_param_config(I2C_NUM_0, &conf);
-    if (err != ESP_OK) {
-        return err;
-    }
-    return i2c_driver_install(I2C_NUM_0, conf.mode, 0, 0, 0);
-}

--- a/main/init.h
+++ b/main/init.h
@@ -4,4 +4,3 @@
 
 void ls_gpio_initialize(void);
 void check_efuse(void) ;
-esp_err_t ls_i2c_master_init(void);

--- a/main/states.c
+++ b/main/states.c
@@ -849,3 +849,20 @@ ls_State ls_state_error_tilt(ls_event event)
     }
     return successor;
 }
+
+ls_State ls_state_error_noaccel(ls_event event)
+{
+    ls_State successor;
+    successor.func = ls_state_error_noaccel;
+    //we're never really going to return
+    for(int i=0; i < 5; i++)
+    {
+        vTaskDelay(pdMS_TO_TICKS(10000));
+        ls_buzzer_play(LS_BUZZER_PLAY_TILT_FAIL);
+        vTaskDelay(pdMS_TO_TICKS(10000));
+        ls_buzzer_play(LS_BUZZER_ALTERNATE_HIGH);
+    }
+    esp_restart(); // software reset of the chip; starts execution again
+    // will not be reached
+    return successor;
+}

--- a/main/states.h
+++ b/main/states.h
@@ -66,3 +66,4 @@ ls_State ls_state_map_build_substate_home(ls_event);
 ls_State ls_state_error_home(ls_event);
 ls_State ls_state_error_map(ls_event);
 ls_State ls_state_error_tilt(ls_event);
+ls_State ls_state_error_noaccel(ls_event);


### PR DESCRIPTION
Remaps GPIO for Nov '21 boards if MPU 6050 accelerometer is detected. Will go to a special fail mode if no accelerometer is detected.