### PR TITLE
delay startup to allow i2c bus to settle

### DIFF
--- a/main/i2c.c
+++ b/main/i2c.c
@@ -90,6 +90,7 @@ bool ls_i2c_init(void)
     if (!_ls_i2c_initialized && i2c_master_init() == ESP_OK)
     {
         _ls_i2c_initialized = true;
+        vTaskDelay(1); // allow bus to settle down
 #ifdef LSDEBUG_I2C
         ls_debug_printf("I2C LIS2DH: %d\n", ls_i2c_has_lis2dh12());
         ls_debug_printf("I2C KXTJ3: %d\n", ls_i2c_has_kxtj3());

--- a/main/ls2022_esp32.c
+++ b/main/ls2022_esp32.c
@@ -62,6 +62,7 @@ static void print_char_val_type(esp_adc_cal_value_t val_type)
  */
 void app_main(void)
 {
+    vTaskDelay(pdMS_TO_TICKS(2000)); // let voltages settle, USB connect
     adc1_mux = xSemaphoreCreateMutex();
     adc2_mux = xSemaphoreCreateMutex();
     print_mux = xSemaphoreCreateMutex();

--- a/main/states.c
+++ b/main/states.c
@@ -850,18 +850,21 @@ ls_State ls_state_error_tilt(ls_event event)
     return successor;
 }
 
+/**
+ * @brief If no accelerometer is found, play a warning tone then attempt to restart MCU
+ *
+ * @param event
+ * @return ls_State
+ */
 ls_State ls_state_error_noaccel(ls_event event)
 {
     ls_State successor;
     successor.func = ls_state_error_noaccel;
-    //we're never really going to return
-    for(int i=0; i < 5; i++)
-    {
-        vTaskDelay(pdMS_TO_TICKS(10000));
-        ls_buzzer_play(LS_BUZZER_PLAY_TILT_FAIL);
-        vTaskDelay(pdMS_TO_TICKS(10000));
-        ls_buzzer_play(LS_BUZZER_ALTERNATE_HIGH);
-    }
+    // we're never really going to return
+    ls_buzzer_play(LS_BUZZER_PLAY_TILT_FAIL);
+    vTaskDelay(pdMS_TO_TICKS(1000));
+    ls_buzzer_play(LS_BUZZER_ALTERNATE_HIGH);
+    vTaskDelay(pdMS_TO_TICKS(29000));
     esp_restart(); // software reset of the chip; starts execution again
     // will not be reached
     return successor;


### PR DESCRIPTION
Also reset after only 30 seconds if no accelerometer is detected.