### PR TITLE
Homing

### DIFF
--- a/main/config.h
+++ b/main/config.h
@@ -108,8 +108,6 @@ gpio_num_t lsgpio_servopulse(void);
 // motor/laser seems to have no trouble at 4800 which is probably too fast
 // is having trouble registering magnet reliably that fast, though.
 #define LS_STEPPER_STEPS_PER_SECOND_MAX 3600
-#define LS_STEPPER_STEPS_PER_SECOND_HOMING 1800
-#define LS_STEPPER_STEPS_PER_SECOND_HOMING_INITIAL 1800
 #define LS_STEPPER_STEPS_PER_SECOND_MAPPING 1800
 #define LS_STEPPER_STEPS_PER_SECOND_WARNING 7200
 #define LS_STEPPER_STEPS_PER_SECOND_DEFAULT 2400
@@ -155,9 +153,16 @@ gpio_num_t lsgpio_servopulse(void);
 #define LS_MAP_ALLOWABLE_MISREAD_PERCENT 12
 #define LS_MAP_HISTOGRAM_BINCOUNT 32
 
-#define LS_HOME_INITIAL_HOMES_TO_AVERAGE 6
-#define LS_HOME_ROTATIONS_ALLOWED 5
-// how often should we rehome if using the map? 10000=10s debug/test, 1800000=30min production
+#define LS_HOME_ATTEMPTS_ALLOWED 3
+#define LS_HOME_HOMINGS_TO_AVERAGE 5
+#define LS_HOME_INITIAL_ROTATIONS 5
+#define LS_HOME_STEPPER_STEPS_PER_SECOND 400
+#define LS_HOME_INITIAL_STEPPER_STEPS_PER_SECOND 1800
+#define LS_HOME_BACKUP_ADDITIONAL_STEPS (LS_STEPPER_STEPS_PER_ROTATION / 10)
+#define LS_HOME_FORWARD_STEPS (LS_STEPPER_STEPS_PER_ROTATION / 4)
+#define LS_HOME_OFFSET_THRESHOLD_TO_REHOME (LS_STEPPER_STEPS_PER_ROTATION/20)
+
+// how often should we check rehome if using the map? 10000=10s debug/test, 1800000=30min production
 #ifdef LSDEBUG_HOMING
 #define LS_STATE_REHOME_TIMER_PERIOD_MS 10000
 #else

--- a/main/config.h
+++ b/main/config.h
@@ -162,9 +162,9 @@ gpio_num_t lsgpio_servopulse(void);
 #define LS_HOME_FORWARD_STEPS (LS_STEPPER_STEPS_PER_ROTATION / 4)
 #define LS_HOME_OFFSET_THRESHOLD_TO_REHOME (LS_STEPPER_STEPS_PER_ROTATION/20)
 
-// how often should we check rehome if using the map? 10000=10s debug/test, 1800000=30min production
+// how often should we check rehome if using the map? 15000=15s debug/test, 1800000=30min production
 #ifdef LSDEBUG_HOMING
-#define LS_STATE_REHOME_TIMER_PERIOD_MS 10000
+#define LS_STATE_REHOME_TIMER_PERIOD_MS 15000
 #else
 #define LS_STATE_REHOME_TIMER_PERIOD_MS 1800000
 #endif

--- a/main/debug.h
+++ b/main/debug.h
@@ -26,7 +26,7 @@
 #include "freertos/semphr.h"
 
 
-//#define LSDEBUG_ENABLE
+#define LSDEBUG_ENABLE
 
 #ifdef LSDEBUG_ENABLE
 
@@ -52,7 +52,7 @@ extern SemaphoreHandle_t print_mux; // in ls2022_esp32.c
 // caution: debugging acceleration is exceptionally verbose
 //#define LSDEBUG_ACCELERATION
 
-//#define LSDEBUG_HOMING
+#define LSDEBUG_HOMING
 
 //#define LSDEBUG_STATES
 

--- a/main/debug.h
+++ b/main/debug.h
@@ -26,7 +26,7 @@
 #include "freertos/semphr.h"
 
 
-#define LSDEBUG_ENABLE
+//#define LSDEBUG_ENABLE
 
 #ifdef LSDEBUG_ENABLE
 
@@ -52,7 +52,7 @@ extern SemaphoreHandle_t print_mux; // in ls2022_esp32.c
 // caution: debugging acceleration is exceptionally verbose
 //#define LSDEBUG_ACCELERATION
 
-#define LSDEBUG_HOMING
+//#define LSDEBUG_HOMING
 
 //#define LSDEBUG_STATES
 

--- a/main/events.c
+++ b/main/events.c
@@ -24,11 +24,30 @@ void ls_event_queue_init(void)
 
 void ls_event_enqueue_noop(void)
 {
+    ls_event_enqueue(LSEVT_NOOP);
+}
+
+/**
+ * Add an event of specified type at the back of the queue; value is NULL
+*/
+void ls_event_enqueue(enum ls_event_t type)
+{
     ls_event event;
-    event.type = LSEVT_NOOP;
+    event.type = type;
+    event.value = NULL;
     xQueueSendToBack(ls_event_queue, (void *)&event, 0);
 }
 
+/**
+ * Insert an event of the specified type at the front of the queue; value is NULL
+*/
+void ls_event_enqueue_front(enum ls_event_t type)
+{
+    ls_event event;
+    event.type = type;
+    event.value = NULL;
+    xQueueSendToFront(ls_event_queue, (void *)&event, 0);
+}
 bool ls_event_queue_has_messages(void)
 {
     return uxQueueMessagesWaiting(ls_event_queue) > 0;

--- a/main/events.h
+++ b/main/events.h
@@ -24,6 +24,7 @@ enum ls_event_t
 {
     LSEVT_NOOP=0, // nothing happened, but we need an event to keep processing internal behavior
     LSEVT_STATE_ENTRY=1, // inserted by state machine on state change to allow new state to initialize
+    LSEVT_SUBSTATE_ENTRY, // inserted by (sub) state to allow successor to initialize
     
     LSEVT_MAGNET_ENTER = 20, // rotating arm's magnet enters detection area
     LSEVT_MAGNET_LEAVE, // rotating arm's magnet leaves detection area
@@ -72,6 +73,8 @@ void ls_event_queue_init(void);
  * 
  */
 void ls_event_enqueue_noop(void);
+void ls_event_enqueue(enum ls_event_t type);
+void ls_event_enqueue_front(enum ls_event_t type);
 bool ls_event_queue_has_messages(void);
 void ls_event_enqueue_noop_if_queue_empty(void);
 void ls_event_empty_queue(void);

--- a/main/magnet.c
+++ b/main/magnet.c
@@ -33,7 +33,7 @@ bool ls_magnet_is_detected(void)
 
 extern QueueHandle_t ls_event_queue;
 int32_t IRAM_ATTR magnet_position;
-int32_t IRAM_ATTR _ls_homing_requested;
+// int32_t IRAM_ATTR _ls_homing_requested;
 
 void IRAM_ATTR magnet_event_isr(void *pvParameter)
 {
@@ -47,12 +47,12 @@ void IRAM_ATTR magnet_event_isr(void *pvParameter)
     ls_event event;
     event.type = gpio_get_level(LSGPIO_MAGNETSENSE) ? LSEVT_MAGNET_LEAVE : LSEVT_MAGNET_ENTER;
     event.value = (void*) magnet_position;
-    if(_ls_homing_requested != 0 && ls_stepper_get_direction()==LS_STEPPER_DIRECTION_FORWARD)
-    {
-        ls_stepper_set_home_position();
-        event.type = LSEVT_MAGNET_HOMED;
-        _ls_homing_requested = 0;
-    }
+    // if(_ls_homing_requested != 0 && ls_stepper_get_direction()==LS_STEPPER_DIRECTION_FORWARD)
+    // {
+    //     ls_stepper_set_home_position();
+    //     event.type = LSEVT_MAGNET_HOMED;
+    //     _ls_homing_requested = 0;
+    // }
     xQueueSendToFrontFromISR(ls_event_queue, (void *)&event, NULL);
 }
 
@@ -63,15 +63,15 @@ void ls_magnet_isr_begin(void)
     gpio_install_isr_service(0); // default, no flags.
     gpio_isr_handler_add(LSGPIO_MAGNETSENSE, &magnet_event_isr, NULL);
     // not homing
-    _ls_homing_requested = 0;
+    // _ls_homing_requested = 0;
 }
 
-bool ls_magnet_is_homing(void)
-{
-    return (_ls_homing_requested == 0 ? false : true);
-}
+// bool ls_magnet_is_homing(void)
+// {
+//     return (_ls_homing_requested == 0 ? false : true);
+// }
 
-void ls_magnet_find_home(void)
-{
-    _ls_homing_requested = 1;
-}
+// void ls_magnet_find_home(void)
+// {
+//     _ls_homing_requested = 1;
+// }

--- a/main/magnet.h
+++ b/main/magnet.h
@@ -21,5 +21,5 @@
 bool ls_magnet_is_detected(void);
 void ls_magnet_isr_begin(void);
 
-bool ls_magnet_is_homing(void);
-void ls_magnet_find_home(void);
+// bool ls_magnet_is_homing(void);
+// void ls_magnet_find_home(void);

--- a/main/selftest.c
+++ b/main/selftest.c
@@ -47,7 +47,7 @@ void _selftest_stepper_behavior(void)
         ls_stepper_reverse(LS_STEPPER_STEPS_PER_ROTATION / 2);
         break;
     case 6:
-        ls_stepper_set_maximum_steps_per_second(LS_STEPPER_STEPS_PER_SECOND_HOMING);
+        ls_stepper_set_maximum_steps_per_second(LS_HOME_STEPPER_STEPS_PER_SECOND);
         ls_stepper_forward(LS_STEPPER_STEPS_PER_ROTATION * 2);
         break;
     case 7:

--- a/main/states.c
+++ b/main/states.c
@@ -534,7 +534,7 @@ ls_State ls_state_secondary_settings(ls_event event)
     case LSEVT_STATE_ENTRY:
         ls_laser_set_mode_off();
         ls_stepper_stop();
-        ls_stepper_sleep();
+        ls_stepper_sleep(); // why? loses homing
         ls_servo_off();
         ls_buzzer_effect(LS_BUZZER_PLAY_SETTINGS_CONTROL_ENTER);
         ls_buzzer_effect(LS_BUZZER_PLAY_SETTINGS_CONTROL_ENTER);
@@ -595,6 +595,7 @@ ls_State ls_state_secondary_settings(ls_event event)
     }         // switch event type
     if (ls_state_secondary_settings != successor.func)
     {
+        ls_substate_home_require_rehome(); 
         ls_buzzer_effect(LS_BUZZER_PLAY_SETTINGS_CONTROL_LEAVE);
         ls_settings_save();
     }
@@ -698,6 +699,7 @@ ls_State ls_state_wakeup(ls_event event)
     case LSEVT_STATE_ENTRY:
         if (ls_map_get_status() == LS_MAP_STATUS_OK)
         {
+            ls_substate_home_require_rehome();
             ls_substate_home_init();
             ls_event_enqueue_noop();
         }

--- a/main/substate_home.c
+++ b/main/substate_home.c
@@ -1,6 +1,6 @@
 /*
-    Control software for URI Laser Scarecrow, 2022 Model
-    Copyright (C) 2022  David H. Brown
+    Control software for URI Laser Scarecrow, 2022-2023 Models
+    Copyright (C) 2022-2023  David H. Brown
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -27,181 +27,207 @@
 extern QueueHandle_t ls_event_queue;
 extern SemaphoreHandle_t print_mux;
 
+/**
+ * Basic plan: rotate quickly to find the magnet.
+ * Back up slowly to clear the magnet.
+ * Move slowly to find the magnet...
+ *   a) if never homed or if position offset > threshold, repeat and set to average
+ *   b) if position offset <= threshold, do nothing... stepper is generally more accurate than magnet
+ */
+
 enum
 {
-    LS_HOME_SUBSTATE_COMPLETE,         // 0
-    LS_HOME_SUBSTATE_FAILED,           // 1
-    LS_HOME_SUBSTATE_ROTATE_TO_MAGNET, // 2
-    LS_HOME_SUBSTATE_WAIT_FOR_NO_STEPS, // 3 -- use only if there may not be a end move event, e.g., on init which could be poweron/wake
-    LS_HOME_SUBSTATE_WAIT_FOR_END_MOVE, // 4 -- use this preferentially when we know we have asked the stepper to move
+    LS_HOME_SUBSTATE_COMPLETE,          // 0
+    LS_HOME_SUBSTATE_FAILED,            // 1
+    LS_HOME_SUBSTATE_ROTATE_TO_MAGNET,  // 2
+    LS_HOME_SUBSTATE_BACKUP,            // 3
+    LS_HOME_SUBSTATE_SLOW_TO_MAGNET,    // 4
+    LS_HOME_SUBSTATE_WAIT_FOR_NO_STEPS, // 5 -- use only if there may not be a end move event, e.g., on init which could be poweron/wake
 } _ls_substate_home_substate_phase;
 
-static bool _ls_substate_home_phase_successful = false;
+static int _ls_home_attempts = 0;
+static bool _ls_home_found_magnet = false;
 
-static int _ls_substate_home_initial_offsets[LS_HOME_INITIAL_HOMES_TO_AVERAGE];
-static int _ls_substate_home_initial_count = 0;
+static int _ls_home_homing_offsets[LS_HOME_HOMINGS_TO_AVERAGE];
+static int _ls_home_homing_index = 0;
 
-static bool _ls_substate_home_find_average = false;
+static bool _ls_home_homing_required = true; // true at power-on
+static ls_stepper_position_t _ls_substate_magnet_entry_offset = 0;
 
-#ifdef LSDEBUG_HOMING
-static int _ls_substate_debug_cumulative_error = 0;
-#endif
-
-static void ls_substate_home_failed(void)
+/**
+ * May be called by previous state... active does not require homing; power-on, wake-up do (when tape map in use).
+ */
+void ls_substate_home_require_rehome()
 {
-    _ls_substate_home_substate_phase = LS_HOME_SUBSTATE_FAILED;
-    ls_event event;
-    event.type = LSEVT_HOME_FAILED;
-    event.value = NULL;
-    xQueueSendToFront(ls_event_queue, (void *)&event, 0);
+    _ls_home_homing_required = true;
 }
-static void ls_substate_home_completed(void)
+void ls_substate_home_init()
 {
-    _ls_substate_home_substate_phase = LS_HOME_SUBSTATE_COMPLETE;
-    ls_event event;
-    event.type = LSEVT_HOME_COMPLETED;
-    event.value = NULL;
-    xQueueSendToFront(ls_event_queue, (void *)&event, 0);
-    ls_buzzer_effect(LS_BUZZER_PLAY_HOME_SUCCESS);
-}
-
-void ls_substate_home_init(void)
-{
-    if (ls_map_get_status() == LS_MAP_STATUS_NOT_BUILT)
-    {
-        _ls_substate_home_find_average = true;
-        _ls_substate_home_initial_count = 0;
-    }
-    else
-    {
-        _ls_substate_home_find_average = false;
-    }
+    _ls_home_attempts = 0;
+    _ls_home_homing_index = 0;
     _ls_substate_home_substate_phase = LS_HOME_SUBSTATE_WAIT_FOR_NO_STEPS;
-    ls_event_enqueue_noop();
-}
-
-static void _ls_substate_home_begin_rotate_to_magnet(void)
-{
-    // enter substate ROTATE_TO_MAGNET
-    _ls_substate_home_substate_phase = LS_HOME_SUBSTATE_ROTATE_TO_MAGNET;
-    ls_magnet_find_home();
-    ls_stepper_set_maximum_steps_per_second(
-        _ls_substate_home_find_average
-            ? LS_STEPPER_STEPS_PER_SECOND_HOMING_INITIAL
-            : LS_STEPPER_STEPS_PER_SECOND_HOMING);
-    ls_stepper_forward(LS_STEPPER_STEPS_PER_ROTATION * LS_HOME_ROTATIONS_ALLOWED);
-    _ls_substate_home_phase_successful = false; // have not yet found magnet
-#ifdef LSDEBUG_HOMING
-    ls_debug_printf("Homing is looking for magnet...\n");
-#endif
+    ls_event_enqueue(LSEVT_SUBSTATE_ENTRY);
 }
 
 /**
  * Use this substate after our own moves (not init)
-*/
-static void _ls_substate_home_handle_backup(ls_event event)
+ */
+static void _ls_substate_home_backup(ls_event event)
 {
     switch (event.type)
     {
-        case LSEVT_STEPPER_FINISHED_MOVE:
-            _ls_substate_home_begin_rotate_to_magnet();
+    case LSEVT_SUBSTATE_ENTRY:
+    {
+        ls_stepper_position_t magnet_position = _ls_substate_magnet_entry_offset < 0 ? _ls_substate_magnet_entry_offset + LS_STEPPER_STEPS_PER_ROTATION : _ls_substate_magnet_entry_offset;
+        // calculate how far to back up
+        ls_stepper_position_t steps = (ls_stepper_get_position() - magnet_position);
+        while (steps < 0)
+        {
+            steps += LS_STEPPER_STEPS_PER_ROTATION;
+        }
+#ifdef LSDEBUG_HOMING
+        ls_debug_printf("Need to back up at least %d steps from stopped position %d to magnet entry at %d.\n",
+                        steps, ls_stepper_get_position(), magnet_position);
+#endif
+        ls_stepper_set_maximum_steps_per_second(LS_HOME_INITIAL_STEPPER_STEPS_PER_SECOND);
+        ls_stepper_reverse(steps + LS_HOME_BACKUP_ADDITIONAL_STEPS);
+    }
+    break;
+
+    case LSEVT_STEPPER_FINISHED_MOVE:
+        _ls_substate_home_substate_phase = LS_HOME_SUBSTATE_SLOW_TO_MAGNET;
+        ls_event_enqueue(LSEVT_SUBSTATE_ENTRY);
         break;
-        default:
-        ; // do nothing
+    default:; // do nothing
     }
 }
 
-
-static void _ls_substate_home_handle_rotate_to_magnet(ls_event event)
+static void _ls_substate_home_slow_to_magnet(ls_event event)
 {
     switch (event.type)
     {
-    case LSEVT_MAGNET_HOMED:
-        _ls_substate_home_phase_successful = true; // found magnet
-        ls_stepper_stop();
-
+    case LSEVT_SUBSTATE_ENTRY:
+        ls_stepper_set_maximum_steps_per_second(LS_HOME_STEPPER_STEPS_PER_SECOND);
+        ls_stepper_forward(LS_HOME_FORWARD_STEPS);
+        break;
+    case LSEVT_MAGNET_ENTER:
 #ifdef LSDEBUG_HOMING
-        _ls_substate_debug_cumulative_error += (int)event.value;
-        ls_debug_printf("homing found magnet with offset of %d steps ; cumulative = %d...\n", (int)event.value, _ls_substate_debug_cumulative_error);
+        ls_debug_printf("Slow step found magnet at offset %d.\n", (int)event.value);
+#endif
+        ls_stepper_stop();
+        /* if offset exceeds threshold, we will need to reset home position (might already be doig that; it's okay to set true twice!)*/
+        if ((int)event.value > LS_HOME_OFFSET_THRESHOLD_TO_REHOME || -((int)event.value) > LS_HOME_OFFSET_THRESHOLD_TO_REHOME)
+        {
+            _ls_home_homing_required = true;
+        }
+        _ls_home_found_magnet = true;
+        _ls_substate_magnet_entry_offset = (int) event.value;
+        break;
+    case LSEVT_STEPPER_FINISHED_MOVE:
+        if (_ls_home_found_magnet)
+        {
+            if (_ls_home_homing_required)
+            {
+                /** if we are setting home position, store offset in array */
+                _ls_home_homing_offsets[_ls_home_homing_index] = _ls_substate_magnet_entry_offset;
+#ifdef LSDEBUG_HOMING
+                    ls_debug_printf(">>>> offset[%d]=%d;\n", _ls_home_homing_index, _ls_home_homing_offsets[_ls_home_homing_index] );
+#endif
+                /** if done collecting offsets, calculate/set new home; succeed */
+                _ls_home_homing_index++;
+                if (_ls_home_homing_index >= LS_HOME_HOMINGS_TO_AVERAGE)
+                {
+                    int average_offset = 0;
+                    for (int i = 0; i < LS_HOME_HOMINGS_TO_AVERAGE; i++)
+                    {
+                        average_offset += _ls_home_homing_offsets[i];
+                    }
+                    average_offset /= LS_HOME_HOMINGS_TO_AVERAGE;
+                    ls_stepper_set_home_offset(average_offset);
+#ifdef LSDEBUG_HOMING
+                    ls_debug_printf("Average offset was %d.\n", average_offset);
+#endif
+                    _ls_substate_home_substate_phase = LS_HOME_SUBSTATE_COMPLETE;
+                    ls_event_enqueue(LSEVT_SUBSTATE_ENTRY);
+                }    // if that was the last offset needed
+                else /** backup for the next offset*/
+                {
+                    _ls_substate_home_substate_phase = LS_HOME_SUBSTATE_BACKUP;
+                    ls_event_enqueue(LSEVT_SUBSTATE_ENTRY);
+                }
+            } // if (full) homing required
+            else
+            { // full rehoming not required
+                _ls_substate_home_substate_phase = LS_HOME_SUBSTATE_COMPLETE;
+                ls_event_enqueue(LSEVT_SUBSTATE_ENTRY);
+            }
+        }    // if magnet found
+        else // magnet not found
+        {
+#ifdef LSDEBUG_HOMING
+            ls_debug_printf("Slow step to magnet failed. Move ended at position %d.\n", (int)ls_stepper_get_position());
+#endif
+            _ls_substate_home_substate_phase = LS_HOME_SUBSTATE_FAILED;
+            ls_event_enqueue(LSEVT_SUBSTATE_ENTRY);
+        }
+        break;
+    default:; // do nothing
+    }
+}
+
+static void _ls_substate_home_rotate_to_magnet(ls_event event)
+{
+    switch (event.type)
+    {
+    case LSEVT_SUBSTATE_ENTRY:
+        ls_stepper_set_maximum_steps_per_second(LS_HOME_INITIAL_STEPPER_STEPS_PER_SECOND);
+        ls_stepper_forward(LS_STEPPER_STEPS_PER_ROTATION * LS_HOME_INITIAL_ROTATIONS);
+        _ls_home_found_magnet = false; // have not yet found magnet
+#ifdef LSDEBUG_HOMING
+        ls_debug_printf("Homing is looking for magnet...\n");
+#endif
+        break;
+    case LSEVT_MAGNET_ENTER:
+        _ls_home_found_magnet = true; // found magnet
+        ls_stepper_stop();
+        _ls_substate_magnet_entry_offset = (ls_stepper_position_t)event.value;
+#ifdef LSDEBUG_HOMING
+        ls_debug_printf("Found magnet in initial rotation(s).\n");
         if (ls_stepper_get_steps_taken() > ((5 * LS_STEPPER_STEPS_PER_ROTATION) / 4))
         {
             ls_debug_printf("WARNING: took > %d rotation to find magnet!\n", ls_stepper_get_steps_taken() / LS_STEPPER_STEPS_PER_ROTATION);
         }
 #endif
-        if (_ls_substate_home_find_average)
-        {
-            // save the offset in _ls_substate_home_initial_offsets except the first [0] is always 0
-            _ls_substate_home_initial_offsets[_ls_substate_home_initial_count] =
-                _ls_substate_home_initial_count == 0 ? 0 : _ls_substate_home_initial_offsets[_ls_substate_home_initial_count - 1] + (int)event.value;
-#ifdef LSDEBUG_HOMING
-            ls_debug_printf("Cumulative offset after home #%d is %d\n", _ls_substate_home_initial_count, _ls_substate_home_initial_offsets[_ls_substate_home_initial_count]);
-#endif
-            _ls_substate_home_initial_count++;
-        }
         break;
     case LSEVT_STEPPER_FINISHED_MOVE:
-        if (_ls_substate_home_phase_successful)
+        if (_ls_home_found_magnet)
         {
-            // have found magnet
-#ifdef LSDEBUG_HOMING
-            ls_debug_printf("stepper stopped after homing found magnet; homing complete\n");
-#endif
-            if (_ls_substate_home_find_average && _ls_substate_home_initial_count < LS_HOME_INITIAL_HOMES_TO_AVERAGE)
-            {
-                // step an increasing fraction around the circle, then home again
-#ifdef LSDEBUG_HOMING
-            ls_debug_printf("Moving backwards #%d steps at maximum speed\n", LS_STEPPER_STEPS_PER_ROTATION * _ls_substate_home_initial_count / LS_HOME_INITIAL_HOMES_TO_AVERAGE);
-#endif
-                ls_stepper_set_maximum_steps_per_second(LS_STEPPER_STEPS_PER_SECOND_MAX);
-                ls_stepper_reverse(LS_STEPPER_STEPS_PER_ROTATION * _ls_substate_home_initial_count / (LS_HOME_INITIAL_HOMES_TO_AVERAGE));
-                _ls_substate_home_substate_phase = LS_HOME_SUBSTATE_WAIT_FOR_END_MOVE;
-            } // we aren't done finding the average offset from the magnet
-            else
-            {
-                if (_ls_substate_home_find_average)
-                {
-                    int average_offset = 0;
-                    for (int i = 0; i < LS_HOME_INITIAL_HOMES_TO_AVERAGE; i++)
-                    {
-                        average_offset += _ls_substate_home_initial_offsets[i];
-                    }
-                    average_offset /= LS_HOME_INITIAL_HOMES_TO_AVERAGE;
-                    ls_stepper_set_home_offset(average_offset);
-#ifdef LSDEBUG_HOMING
-                    ls_debug_printf("Average offset was %d\n", average_offset);
-                    _ls_substate_debug_cumulative_error = 0;
-#endif
-                } // we can compute the average offset from the magnet
-
-                ls_substate_home_completed();
-
-                ls_event_enqueue_noop();
-            } // we are done finding home, average or not
-        }     // phase was not successful
+            _ls_substate_home_substate_phase = LS_HOME_SUBSTATE_BACKUP;
+            ls_event_enqueue(LSEVT_SUBSTATE_ENTRY);
+        } // if found magnet
         else
         {
             // did not find magnet
-            _ls_substate_home_substate_phase = LS_HOME_SUBSTATE_FAILED;
-            ls_event_enqueue_noop();
 #ifdef LSDEBUG_HOMING
-            ls_debug_printf("homing could not find magnet in %d rotations\n", LS_HOME_ROTATIONS_ALLOWED);
+            ls_debug_printf("FAILED: homing could not find magnet in %d rotations\n", LS_HOME_INITIAL_ROTATIONS);
 #endif
+            _ls_substate_home_substate_phase = LS_HOME_SUBSTATE_FAILED;
+            ls_event_enqueue(LSEVT_SUBSTATE_ENTRY);
         }
     default:;
     } // switch on event type
 }
 
-
 /**
- * This is a rather awkward method that can cause problems. 
- * Use only on first entry to homing in case the stepper is already stopped 
+ * This is a rather awkward method that can cause problems.
+ * Use only on first entry to homing in case the stepper is already stopped
  * and there is not going to be any LSEVT_STEPPER_FINISHED_MOVE
  * (e.g., power-on or wake)
-*/
+ */
 static void _ls_substate_home_wait_for_stop(void)
 {
 #ifdef LSDEBUG_HOMING
-        ls_debug_printf(ls_stepper_is_moving() ? "Waiting to stop...\n" : "Already stopped...\n");
+    ls_debug_printf(ls_stepper_is_moving() ? "Waiting to stop...\n" : "Already stopped...\n");
 #endif
     while (ls_stepper_is_moving())
     {
@@ -209,7 +235,23 @@ static void _ls_substate_home_wait_for_stop(void)
     }
     // a pending LSEVT_STEPPER_FINISHED_MOVE would confuse homing
     ls_event_empty_queue();
-    _ls_substate_home_begin_rotate_to_magnet();
+    _ls_substate_home_substate_phase = LS_HOME_SUBSTATE_ROTATE_TO_MAGNET;
+    ls_event_enqueue(LSEVT_SUBSTATE_ENTRY);
+}
+
+static void _ls_substate_home_failed(ls_event event)
+{
+    _ls_home_attempts++;
+    if (_ls_home_attempts >= LS_HOME_ATTEMPTS_ALLOWED)
+    {
+        _ls_substate_home_substate_phase = LS_HOME_SUBSTATE_FAILED;
+        ls_event_enqueue_front(LSEVT_HOME_FAILED);
+    }
+    else // try again from the top
+    {
+        _ls_substate_home_substate_phase = LS_HOME_SUBSTATE_WAIT_FOR_NO_STEPS;
+        ls_event_enqueue(LSEVT_SUBSTATE_ENTRY);
+    }
 }
 
 void ls_substate_home_handle_event(ls_event event)
@@ -229,18 +271,21 @@ void ls_substate_home_handle_event(ls_event event)
         _ls_substate_home_wait_for_stop();
         break;
     case LS_HOME_SUBSTATE_ROTATE_TO_MAGNET:
-        _ls_substate_home_handle_rotate_to_magnet(event);
+        _ls_substate_home_rotate_to_magnet(event);
+        break;
+    case LS_HOME_SUBSTATE_BACKUP:
+        _ls_substate_home_backup(event);
+        break;
+    case LS_HOME_SUBSTATE_SLOW_TO_MAGNET:
+        _ls_substate_home_slow_to_magnet(event);
         break;
     case LS_HOME_SUBSTATE_FAILED:
-        ls_substate_home_failed();
+        _ls_substate_home_failed(event);
         break;
     case LS_HOME_SUBSTATE_COMPLETE:
-        ls_substate_home_completed();
+        _ls_home_homing_required = false;
+        ls_buzzer_effect(LS_BUZZER_PLAY_HOME_SUCCESS);
+        ls_event_enqueue_front(LSEVT_HOME_COMPLETED);
         break;
-    case LS_HOME_SUBSTATE_WAIT_FOR_END_MOVE:
-        _ls_substate_home_handle_backup(event);
     }
-#ifdef LSDEBUG_HOMING
-    ls_debug_printf("(finished event %d during phase %d)\n", event.type, _ls_substate_home_substate_phase);
-#endif
 }

--- a/main/substate_home.h
+++ b/main/substate_home.h
@@ -20,3 +20,4 @@
 
 void ls_substate_home_init(void);
 void ls_substate_home_handle_event(ls_event);
+void ls_substate_home_require_rehome(void);


### PR DESCRIPTION
Turns out the stepper is much more repeatable than the magnet, at least at speed. This homing algorithm slow-steps to the magnet 5 times to find an average position. Rehoming will check whether the magnet is found within a threshold of where it's supposed to be and leave things as they are if it is. Otherwise, another average will be taken. On the 2022 scarecrow with an A4988 driver, the repeatability of the home position improved to within +/- 10 microsteps, (+/- 1.125 degrees). 